### PR TITLE
Fixed serverToken constructor

### DIFF
--- a/src/main/java/com/victorsima/uber/UberClient.java
+++ b/src/main/java/com/victorsima/uber/UberClient.java
@@ -55,7 +55,7 @@ public class UberClient {
      * @param logLevel
      */
     public UberClient(String serverToken, RestAdapter.LogLevel logLevel) {
-        this(null, null, null, null, null, false, logLevel);
+        this(null, null, null, serverToken, null, false, logLevel);
     }
 
     /**


### PR DESCRIPTION
UberClient(serverToken, logLevel) constructor previously yielded a null value for serverToken, ignoring the value put into the constructor.
